### PR TITLE
Port syntax to GFM

### DIFF
--- a/git-cheat-sheet.md
+++ b/git-cheat-sheet.md
@@ -3,48 +3,50 @@ Git Cheat Sheet
 
 ###### Git Cheat Sheet © 2024 by Leanne Keeley & Sebastian Roman is licensed under Attribution-NonCommercial 4.0 International. To view a copy of this license, visit http://creativecommons.org/licenses/by-nc/4.0/
 
-*Last updated 2024-03-21*
+*Last updated 2024-03-28*
 
-**⚠️ Please make sure Git is installed first!**  
-[Here is a guide on how to install Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+> [!WARNING]
+> **Please make sure Git is installed first!**  
+> [Here is a guide on how to install Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 
 Git terms
 ---------
 
-Branch
+__Branch__
 : A separate version of the code, used for testing new features
 
-Develop (Branch)
+__Develop (Branch)__
 : Usually the branch that you merge changes to
 
-Fork
-: *noun* A copy of a repository  
-*verb* To create a copy of a repository
+__Fork__
+: <sub>noun</sub> A copy of a repository  
+&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; <sub>verb</sub> To create a copy of a repository
 
-Head
+__Head__
 : The most recent commit
 
-Master (Branch)
+__Master (Branch)__
 : The main branch of your repository
 
-Pull request
+__Pull request__
 : Ask the owner of a repository to merge your changes into the project
 
-Remote/Origin/Upstream
+__Remote/Origin/Upstream__
 : These refer to the location of the repository online. This is where changes are pushed to ([github](https://github.com/), [gitlab](https://gitlab.com/), etc.)
 
-Repository/Repo
+__Repository/Repo__
 : A container for your project
 
-.gitignore
+__.gitignore__
 : This is a file that contains the names of things you want git to ignore
 
 Git Commands
 ------------
 
-**ℹ️ These comands are structured as `git [command] [flags] [arguments]`**  
-Example: `git checkout -b main`   
-In this example, `checkout` is the command, `-b` is the flag, and `main` is the argument
+> [!NOTE]
+> **These comands are structured as `git [command] [flags] [arguments]`**  
+> Example: `git checkout -b main`   
+> In this example, `checkout` is the command, `-b` is the flag, and `main` is the argument
 
 `add [file]`
 : Adds the named file to your git repository
@@ -58,12 +60,12 @@ In this example, `checkout` is the command, `-b` is the flag, and `main` is the 
 `checkout [branch or file]`
 : Switch to a different branch, or pull the last committed version of a file
 
-`-b` flag allows you to create a new branch
+&nbsp; &nbsp; &nbsp; &nbsp; `-b` flag allows you to create a new branch
 
 `commit`
 : Adds a save point with new changes. Descriptive comments made it much easier to understand what change you saved
 
-`-am '[comment]'` flag allows you to add comment without going into a text editor
+&nbsp; &nbsp; &nbsp; &nbsp; `-am '[comment]'` flag allows you to add comment without going into a text editor
 
 `fetch`
 : Download copies of all the files in a branch to your local machine

--- a/git-cheat-sheet.md
+++ b/git-cheat-sheet.md
@@ -12,33 +12,33 @@ Git Cheat Sheet
 Git terms
 ---------
 
-__Branch__
-: A separate version of the code, used for testing new features
+__Branch__:  
+&nbsp; &nbsp; &nbsp; &nbsp; A separate version of the code, used for testing new features
 
-__Develop (Branch)__
-: Usually the branch that you merge changes to
+__Develop (Branch)__:  
+&nbsp; &nbsp; &nbsp; &nbsp; Usually the branch that you merge changes to
 
-__Fork__
-: <sub>noun</sub> A copy of a repository  
-&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; <sub>verb</sub> To create a copy of a repository
+__Fork__:  
+&nbsp; &nbsp; &nbsp; &nbsp; <sub>noun</sub> A copy of a repository  
+&nbsp; &nbsp; &nbsp; &nbsp; <sub>verb</sub> To create a copy of a repository
 
-__Head__
-: The most recent commit
+__Head__:  
+&nbsp; &nbsp; &nbsp; &nbsp; The most recent commit
 
-__Master (Branch)__
-: The main branch of your repository
+__Master (Branch)__:  
+&nbsp; &nbsp; &nbsp; &nbsp; The main branch of your repository
 
-__Pull request__
-: Ask the owner of a repository to merge your changes into the project
+__Pull request__:  
+&nbsp; &nbsp; &nbsp; &nbsp; Ask the owner of a repository to merge your changes into the project
 
-__Remote/Origin/Upstream__
-: These refer to the location of the repository online. This is where changes are pushed to ([github](https://github.com/), [gitlab](https://gitlab.com/), etc.)
+__Remote/Origin/Upstream__:  
+&nbsp; &nbsp; &nbsp; &nbsp; These refer to the location of the repository online. This is where changes are pushed to ([github](https://github.com/), [gitlab](https://gitlab.com/), etc.)
 
-__Repository/Repo__
-: A container for your project
+__Repository/Repo__:  
+&nbsp; &nbsp; &nbsp; &nbsp; A container for your project
 
-__.gitignore__
-: This is a file that contains the names of things you want git to ignore
+__.gitignore__:  
+&nbsp; &nbsp; &nbsp; &nbsp;This is a file that contains the names of things you want git to ignore
 
 Git Commands
 ------------
@@ -48,54 +48,54 @@ Git Commands
 > Example: `git checkout -b main`   
 > In this example, `checkout` is the command, `-b` is the flag, and `main` is the argument
 
-`add [file]`
-: Adds the named file to your git repository
+`add [file]`:  
+&nbsp; &nbsp; &nbsp; &nbsp; Adds the named file to your git repository
 
-`branch`
-: Shows you the branch you are currently in
+`branch`:  
+&nbsp; &nbsp; &nbsp; &nbsp; Shows you the branch you are currently in
 
-`clone https://github.com/[username]/[repository].git`
-: Copies a repository onto your local machine
+`clone https://github.com/[username]/[repository].git`:  
+&nbsp; &nbsp; &nbsp; &nbsp; Copies a repository onto your local machine
 
-`checkout [branch or file]`
-: Switch to a different branch, or pull the last committed version of a file
+`checkout [branch or file]`:  
+&nbsp; &nbsp; &nbsp; &nbsp; Switch to a different branch, or pull the last committed version of a file
 
 &nbsp; &nbsp; &nbsp; &nbsp; `-b` flag allows you to create a new branch
 
-`commit`
-: Adds a save point with new changes. Descriptive comments made it much easier to understand what change you saved
+`commit`:  
+&nbsp; &nbsp; &nbsp; &nbsp; Adds a save point with new changes. Descriptive comments made it much easier to understand what change you saved
 
 &nbsp; &nbsp; &nbsp; &nbsp; `-am '[comment]'` flag allows you to add comment without going into a text editor
 
-`fetch`
-: Download copies of all the files in a branch to your local machine
+`fetch`:  
+&nbsp; &nbsp; &nbsp; &nbsp; Download copies of all the files in a branch to your local machine
 
-`init`
-: Creates a new git repository
+`init`:  
+&nbsp; &nbsp; &nbsp; &nbsp; Creates a new git repository
 
-`log`
-: Show you all the commits, merges, etc. to the current branch
+`log`:  
+&nbsp; &nbsp; &nbsp; &nbsp; Show you all the commits, merges, etc. to the current branch
 
-`merge [branch]`
-: Combines the changes from the current branch into the named branch
+`merge [branch]`:  
+&nbsp; &nbsp; &nbsp; &nbsp; Combines the changes from the current branch into the named branch
 
-`pull`
-: Same as fetch, but also merges those changes into the current branch
+`pull`:  
+&nbsp; &nbsp; &nbsp; &nbsp; Same as fetch, but also merges those changes into the current branch
 
-`push`
-: Send committed changes to the origin (ex. github)
+`push`:  
+&nbsp; &nbsp; &nbsp; &nbsp; Send committed changes to the origin (ex. github)
 
-`rebase [branch]`
-: Update the current branch to the status of the named branch
+`rebase [branch]`:  
+&nbsp; &nbsp; &nbsp; &nbsp; Update the current branch to the status of the named branch
 
-`reset old-commit / revert head`
-: Undoes commits, takes your project back to a previous state
+`reset old-commit / revert head`:  
+&nbsp; &nbsp; &nbsp; &nbsp; Undoes commits, takes your project back to a previous state
 
-`stash`
-: Stashes and removes uncommitted changes
+`stash`:  
+&nbsp; &nbsp; &nbsp; &nbsp; Stashes and removes uncommitted changes
 
-`stash pop`
-: Reapply changes previously stashed
+`stash pop`:  
+&nbsp; &nbsp; &nbsp; &nbsp; Reapply changes previously stashed
 
-`status`
-: Shows you the current status of your repository. Use this often!
+`status`:  
+&nbsp; &nbsp; &nbsp; &nbsp; Shows you the current status of your repository. Use this often!


### PR DESCRIPTION
Some of the syntax is rewritten to take advantage of Github Flavored Markdown (GFM) because certain features are available in GFM, like alerts, that aren't in other markdown dialects, and some features of other markdown dialects, like defininitions, aren't available in GFM. This will allow the Github version of this cheat sheet to display as is intended